### PR TITLE
Add requirements.txt + fix typo that caused the script to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@
 To recover our manual alignments you will need to have access to AMR Release 1.0.
 Unzip the release files and cd to corpus/release1/unsplit. From there run:
 
-`cat amr-release-1.0-bolt.txt amr-release-1.0-consensus.txt  amr-release-1.0-dfa.txt  amr-release-1.0-mt09sdl.txt amr-release-1.0-xinhua.txt amr-release-1.0-proxy.txt > ~/YOUR_PATH/amr_ud/data/amr-release-1.0-all.txt`
+```
+cat amr-release-1.0-bolt.txt amr-release-1.0-consensus.txt  amr-release-1.0-dfa.txt  amr-release-1.0-mt09sdl.txt amr-release-1.0-xinhua.txt amr-release-1.0-proxy.txt > ~/YOUR_PATH/amr_ud/data/amr-release-1.0-all.txt
+```
 
 to concatenate all release files into one.
 
 
 Then cd to amr_ud and run:
 
-```python2 dp1.py
+```
+python2 dp1.py
 patch ./alignments/aligned_amrs_reconstructed.txt -i ./alignments/amrs.patch -o ./alignments/aligned_amrs.txt
 python2 dp2.py
 patch ./alignments/ud_parses_ldc_reconstructed.txt -i ./alignments/ud_parses.patch -o ./alignments/ud_parses_patched.txt

--- a/parse.py
+++ b/parse.py
@@ -199,7 +199,7 @@ def extract_all_concepts(full_amr):
 
 
 def parse_amr(tokens, concept_dict, relations, current_relation, open_concepts, none_counter, jamr_counter = {},
-              jgamr=False, isi=False, nesting_level=0):
+              jamr=False, isi=False, nesting_level=0):
     """
     Given an AMR represented as a string, extract all edges between nodes.
     :param tokens: as yet unparsed portion of the AMR represented as a string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib==2.2.2
+networkx==2.1
+pycorenlp==0.3.0


### PR DESCRIPTION
When trying to run `dp1.py` I found these modules to be required. It's better to specify it explicitly.